### PR TITLE
(WIP) rpc: fix some failing tests and syncing

### DIFF
--- a/p2p/syncer_test.go
+++ b/p2p/syncer_test.go
@@ -49,28 +49,28 @@ func TestSyncer(t *testing.T) {
 	b := sim.Chain[len(sim.Chain)-1]
 	n1.s.Broadcast(&MsgRelayBlock{b})
 
-	time.Sleep(time.Second / 2)
+	time.Sleep(500 * time.Millisecond)
 	if n1.c.Tip() != n2.c.Tip() {
 		t.Fatal("peers did not sync:", n1.c.Tip(), n2.c.Tip())
 	}
 
-	// relay old block - shouldnt change anything
+	// relay old block - shouldn't change anything
 	oldTip := n1.c.Tip()
 	b = sim.Chain[len(sim.Chain)-2]
 	n1.s.Broadcast(&MsgRelayBlock{b})
 
-	time.Sleep(time.Second / 2)
+	time.Sleep(500 * time.Millisecond)
 	if n1.c.Tip() != oldTip || n2.c.Tip() != oldTip {
 		t.Fatalf("tip went backwards (expected: %v): %v %v", oldTip, n1.c.Tip(), n2.c.Tip())
 	}
 
-	// relay invalid block - shouldnt change anything
+	// relay invalid block - shouldn't change anything
 	b = sim.Chain[len(sim.Chain)-1]
 	b.Header.Height = 999
 
 	n1.s.Broadcast(&MsgRelayBlock{b})
 
-	time.Sleep(time.Second / 2)
+	time.Sleep(500 * time.Millisecond)
 	if n1.c.Tip() != oldTip || n2.c.Tip() != oldTip {
 		t.Fatalf("accepted invalid tip (expected: %v): %v %v", oldTip, n1.c.Tip(), n2.c.Tip())
 	}


### PR DESCRIPTION
This PR fixes some tests that broke as a result of the switch to RPC.  It also updates logic in handleMsgRelayBlock to fix some elements of syncing that were broken by the change.  Unfortunately, this PR breaks the final check in `TestMsgRelayBlock`.  This seems to have to do with how `handleMsgRelayBlock` returns the passed `msg` instead of history from the syncer's chain manager like it used to.  Implementing the old logic causes syncing problems elsewhere so I am unsure of what the solution to this problem is. 