### PR TITLE
p2p: Add support for parallel sync

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -279,6 +279,9 @@ func (m *Manager) AddBlocks(blocks []sunyata.Block) (*consensus.ScratchChain, er
 	// the chain may already contain some of the supplied blocks; ignore
 	// the ones we already have
 	have := chain.ValidTip().Height - (index.Height - 1)
+	if have > uint64(len(blocks)) {
+		return nil, fmt.Errorf("not enough blocks")
+	}
 	blocks = blocks[have:]
 
 	for _, b := range blocks {


### PR DESCRIPTION
Currently we download headers and blocks synchronously from one peer at a time.  This pull request adds support for downloading blocks from multiple of the syncer's peers at a time.